### PR TITLE
Added code to detect development vs production builds

### DIFF
--- a/COVIDWatch iOS/AppDelegate.swift
+++ b/COVIDWatch iOS/AppDelegate.swift
@@ -22,10 +22,31 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var signedReportsUploader: SignedReportsUploader?
     var currentUserExposureNotifier: CurrentUserExposureNotifier?
-    
+
+    static func getFirestore() -> Firestore {
+        if getAppScheme() == .development {
+            if let f = FirebaseApp.app() {
+                // override the firestore host to use the local emulator
+                let firestore = Firestore.firestore(app: f)
+                let settings = FirestoreSettings()
+                settings.host = getLocalFirebaseHost()
+                settings.isSSLEnabled = false
+                firestore.settings = settings
+                return firestore
+            }
+        }
+        return Firestore.firestore()
+    }
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        let appScheme = getAppScheme()
+        let apiUrl = getAPIUrl(appScheme)
+
         FirebaseApp.configure()
+
+        print("Starting app with: \(appScheme) and API Url: \(apiUrl)")
+
         window?.tintColor = UIColor(red: 50.0/255.0, green: 90.0/255.0, blue: 169.0/255.0, alpha: 1.0)
         if #available(iOS 13.0, *) {
             self.registerBackgroundTasks()

--- a/COVIDWatch iOS/Firestore/SignedReportsDownloadOperation.swift
+++ b/COVIDWatch iOS/Firestore/SignedReportsDownloadOperation.swift
@@ -13,6 +13,8 @@ class SignedReportsDownloadOperation: Operation {
     
     public var querySnapshot: QuerySnapshot?
     public var error: Error?
+
+    private var db: Firestore = AppDelegate.getFirestore()
     
     init(sinceDate: Date) {
         self.sinceDate = sinceDate
@@ -22,7 +24,7 @@ class SignedReportsDownloadOperation: Operation {
     override func main() {
         let semaphore = DispatchSemaphore(value: 0)
         os_log("Downloading signed reports...", log: .app)
-        Firestore.firestore().collection(Firestore.Collections.signedReports)
+        self.db.collection(Firestore.Collections.signedReports)
             .whereField(Firestore.Fields.timestamp, isGreaterThan: Timestamp(date: self.sinceDate))
             // TODO: isAuthenticatedByHealthOrganization can only be written by an authenticated user
             // .whereField(Firestore.Fields.isAuthenticatedByHealthOrganization, isEqualTo: true)

--- a/COVIDWatch iOS/Info.plist
+++ b/COVIDWatch iOS/Info.plist
@@ -29,10 +29,14 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LocalIP</key>
+	<string></string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Allow access to Bluetooth to enable privacy-preserving contact tracing.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Allow access to Bluetooth to enable privacy-preserving contact tracing.</string>
+	<key>SchemeName</key>
+	<string>covidwatch-ios-prod</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>

--- a/COVIDWatch iOS/Utility/Environment.swift
+++ b/COVIDWatch iOS/Utility/Environment.swift
@@ -1,0 +1,58 @@
+//
+//  Environment.swift
+//  COVIDWatch iOS
+//
+//  Created by Madhava Jay on 16/4/20.
+//  Copyright © 2020 IZE. All rights reserved.
+//
+
+import Foundation
+
+enum AppScheme {
+    case production
+    case development
+}
+
+func getLocalIP() -> String {
+    // sometimes the xcode ip sniff fails, in that case you can just
+    // hard code it during development
+    //return "192.168.176.132"
+    if let localIP = Bundle.main.infoDictionary?["LocalIP"] as? String {
+        return localIP
+    }
+    return "localhost"
+}
+
+func getLocalFirebaseHost() -> String {
+    let firebasePort = 8080
+    return "\(getLocalIP()):\(firebasePort)"
+}
+
+func getAPIUrl(_ scheme: AppScheme) -> String {
+    func getLocalURL() -> String {
+        let localProtocol = "http://"
+        let localPort = 5001
+        let projectSlug = "tagstwo-431e3/us-central1"
+        return "\(localProtocol)\(getLocalIP()):\(localPort)/\(projectSlug)"
+    }
+
+    switch scheme {
+    case .production:
+        return "https://us-central1-tagstwo-431e3.cloudfunctions.net"
+    default:
+        return getLocalURL()
+    }
+}
+
+func getAppScheme() -> AppScheme {
+    if let schemeName = Bundle.main.infoDictionary?["SchemeName"] as? String {
+        print("Scheme Name: \(schemeName)")
+        switch schemeName {
+        case "covidwatch-ios-prod":
+            return .production
+        default:
+            return .development
+        }
+    }
+    return .development
+}

--- a/COVIDWatch.xcodeproj/project.pbxproj
+++ b/COVIDWatch.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		2DFDC5BD24190ABA00B108F8 /* COVIDWatch_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DFDC5BC24190ABA00B108F8 /* COVIDWatch_iOSTests.swift */; };
 		2DFDC5C824190ABA00B108F8 /* COVIDWatch_iOSUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DFDC5C724190ABA00B108F8 /* COVIDWatch_iOSUITests.swift */; };
 		B1D85F9E809BCC12318E2223 /* Pods_COVIDWatch_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 067227CBFA80D8CE4D90B6F6 /* Pods_COVIDWatch_iOS.framework */; };
+		E2CE9F792448162F00AE46B4 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CE9F782448162F00AE46B4 /* Environment.swift */; };
 		F59A36E1AD0F8E40375BE630 /* Pods_COVIDWatch_iOS_COVIDWatch_iOSUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B100AAFD7EDE7205A094091D /* Pods_COVIDWatch_iOS_COVIDWatch_iOSUITests.framework */; };
 /* End PBXBuildFile section */
 
@@ -114,6 +115,7 @@
 		A40ADD9EFD1AE21913D43EB7 /* Pods-COVIDWatch iOS-COVIDWatch iOSUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-COVIDWatch iOS-COVIDWatch iOSUITests.release.xcconfig"; path = "Target Support Files/Pods-COVIDWatch iOS-COVIDWatch iOSUITests/Pods-COVIDWatch iOS-COVIDWatch iOSUITests.release.xcconfig"; sourceTree = "<group>"; };
 		A5B373FB19305537F2E1D4A1 /* Pods-COVID-19 Risk.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-COVID-19 Risk.debug.xcconfig"; path = "Target Support Files/Pods-COVID-19 Risk/Pods-COVID-19 Risk.debug.xcconfig"; sourceTree = "<group>"; };
 		B100AAFD7EDE7205A094091D /* Pods_COVIDWatch_iOS_COVIDWatch_iOSUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_COVIDWatch_iOS_COVIDWatch_iOSUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E2CE9F782448162F00AE46B4 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		ECF661F853918EA18D1C729B /* Pods-COVIDWatch iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-COVIDWatch iOSTests.debug.xcconfig"; path = "Target Support Files/Pods-COVIDWatch iOSTests/Pods-COVIDWatch iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -194,6 +196,7 @@
 				2DDEBF5F241A369A005BE9A8 /* UIWindow+ViewControllerUtility.swift */,
 				2DC231EB241BA17B00216404 /* UIViewController+ErrorPresenting.swift */,
 				2D30EFC2242268010063C211 /* Array+Chunked.swift */,
+				E2CE9F782448162F00AE46B4 /* Environment.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -308,6 +311,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2DFDC5CC24190ABA00B108F8 /* Build configuration list for PBXNativeTarget "COVIDWatch iOS" */;
 			buildPhases = (
+				E2CE9F7724480E9500AE46B4 /* Environment */,
 				FF47CA4630BD6DE9380890D3 /* [CP] Check Pods Manifest.lock */,
 				2DFDC59B24190AB700B108F8 /* Sources */,
 				2DFDC59C24190AB700B108F8 /* Frameworks */,
@@ -516,6 +520,24 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-COVIDWatch iOS/Pods-COVIDWatch iOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		E2CE9F7724480E9500AE46B4 /* Environment */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Environment;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# contents of SCHEME_FILE is definied in the scheme > build > pre action\n# SCHEME_FILE path is definied in Target Build Settings User Defined ENV vars\necho \"Running Scheme and IP Sniffer\"\nSCHEME_NAME=`cat ${SCHEME_FILE}`\necho $SCHEME_NAME\necho $INFOPLIST_FILE\n/usr/libexec/PlistBuddy -c \"Set :SchemeName \\\"$SCHEME_NAME\\\"\" \"$INFOPLIST_FILE\"\n\nif [ \"$SCHEME_NAME\" = \"covidwatch-ios-dev\" ]; then\nLOCAL_IP=$(LANG=C /sbin/ifconfig  | sed -ne $'/127.0.0.1/ ! { s/^[ \\t]*inet[ \\t]\\\\{1,99\\\\}\\\\(addr:\\\\)\\\\{0,1\\\\}\\\\([0-9.]*\\\\)[ \\t\\/].*$/\\\\2/p; }' | head -n 1)\nelse\nLOCAL_IP=\"\"\nfi;\n/usr/libexec/PlistBuddy -c \"Set :LocalIP \\\"$LOCAL_IP\\\"\" \"$INFOPLIST_FILE\"\n";
+		};
 		FC6303ED284885D616B54BE3 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -586,6 +608,7 @@
 				2DDEBF60241A369B005BE9A8 /* UIWindow+ViewControllerUtility.swift in Sources */,
 				2DC231EC241BA17B00216404 /* UIViewController+ErrorPresenting.swift in Sources */,
 				2DC231EE241BA27800216404 /* AppDelegate+UserNotificationCenter.swift in Sources */,
+				E2CE9F792448162F00AE46B4 /* Environment.swift in Sources */,
 				2D48C279243A1703002858F9 /* AppDelegate.swift in Sources */,
 				2D52B6922439B9800096BC5C /* GenericPasswordConvertible.swift in Sources */,
 				2DF8F3D32430C503001C88EF /* AppDelegate+BackgroundFetch.swift in Sources */,
@@ -762,6 +785,7 @@
 				DEVELOPMENT_TEAM = S647QX78WZ;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/COVIDWatch iOS/Info.plist";
+				INTERMEDIATES_OUTPUT_DIR = "${PROJECT_DIR}/build/intermediates/${CONFIGURATION}/";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -770,6 +794,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.covidwatch.ios;
 				PRODUCT_NAME = "COVID Watch";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SCHEME_FILE = "${INTERMEDIATES_OUTPUT_DIR}current_scheme.txt";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -786,6 +811,7 @@
 				DEVELOPMENT_TEAM = S647QX78WZ;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/COVIDWatch iOS/Info.plist";
+				INTERMEDIATES_OUTPUT_DIR = "${PROJECT_DIR}/build/intermediates/${CONFIGURATION}/";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -794,6 +820,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.covidwatch.ios;
 				PRODUCT_NAME = "COVID Watch";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SCHEME_FILE = "${INTERMEDIATES_OUTPUT_DIR}current_scheme.txt";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -931,9 +958,9 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		2D63900C243E39BD00EA97FA /* XCRemoteSwiftPackageReference "tcn-client-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/TCNCoalition/tcn-client-ios";
+			repositoryURL = "https://github.com/madhavajay/tcn-client-ios";
 			requirement = {
-				branch = master;
+				branch = swift-version;
 				kind = branch;
 			};
 		};

--- a/COVIDWatch.xcodeproj/xcshareddata/xcschemes/covidwatch-ios-dev.xcscheme
+++ b/COVIDWatch.xcodeproj/xcshareddata/xcschemes/covidwatch-ios-dev.xcscheme
@@ -1,10 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1130"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "rm -rf ${INTERMEDIATES_OUTPUT_DIR}&#10;mkdir -p ${INTERMEDIATES_OUTPUT_DIR}&#10;echo covidwatch-ios-dev &gt; ${SCHEME_FILE}&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "2DFDC59E24190AB700B108F8"
+                     BuildableName = "COVID Watch.app"
+                     BlueprintName = "COVIDWatch iOS"
+                     ReferencedContainer = "container:COVIDWatch.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/COVIDWatch.xcodeproj/xcshareddata/xcschemes/covidwatch-ios-prod.xcscheme
+++ b/COVIDWatch.xcodeproj/xcshareddata/xcschemes/covidwatch-ios-prod.xcscheme
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "rm -rf ${INTERMEDIATES_OUTPUT_DIR}&#10;mkdir -p ${INTERMEDIATES_OUTPUT_DIR}&#10;echo covidwatch-ios-prod &gt; ${SCHEME_FILE}&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "2DFDC59E24190AB700B108F8"
+                     BuildableName = "COVID Watch.app"
+                     BlueprintName = "COVIDWatch iOS"
+                     ReferencedContainer = "container:COVIDWatch.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DFDC59E24190AB700B108F8"
+               BuildableName = "COVID Watch.app"
+               BlueprintName = "COVIDWatch iOS"
+               ReferencedContainer = "container:COVIDWatch.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DFDC5B724190ABA00B108F8"
+               BuildableName = "COVIDWatch iOSTests.xctest"
+               BlueprintName = "COVIDWatch iOSTests"
+               ReferencedContainer = "container:COVIDWatch.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DFDC5C224190ABA00B108F8"
+               BuildableName = "COVIDWatch iOSUITests.xctest"
+               BlueprintName = "COVIDWatch iOSUITests"
+               ReferencedContainer = "container:COVIDWatch.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DFDC59E24190AB700B108F8"
+            BuildableName = "COVID Watch.app"
+            BlueprintName = "COVIDWatch iOS"
+            ReferencedContainer = "container:COVIDWatch.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DFDC59E24190AB700B108F8"
+            BuildableName = "COVID Watch.app"
+            BlueprintName = "COVIDWatch iOS"
+            ReferencedContainer = "container:COVIDWatch.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -6,34 +6,45 @@ BLE is a low power protocol with cross-platform OS support for background operat
 
 The approach currently being investigated utilizes BLE functionality for background advertisement and scanning. Due to different system requirements for Android and iOS, the protocol works differently depending on the operating systems of the devices involved. The key challenges are:
 
-  1) iOS devices acting as peripherals in the background can only be found by centrals that are scanning for their specific service UUID. These peripherals must establish a connection to transfer any data.
-  2) Android devices have an unfixed bug (https://issuetracker.google.com/issues/125138967) where subsequent connections with many devices can cause the bluetooth system to lock up.
+1. iOS devices acting as peripherals in the background can only be found by centrals that are scanning for their specific service UUID. These peripherals must establish a connection to transfer any data.
+2. Android devices have an unfixed bug (https://issuetracker.google.com/issues/125138967) where subsequent connections with many devices can cause the bluetooth system to lock up.
 
-The current solution is a hybrid model that is asymmetric for communication between iOS and Android. All devices will simultaneously act as peripherals and centrals, but only some devices will be able to detect others, and only some devices will need to establish a connection to exchange data. 
+The current solution is a hybrid model that is asymmetric for communication between iOS and Android. All devices will simultaneously act as peripherals and centrals, but only some devices will be able to detect others, and only some devices will need to establish a connection to exchange data.
+
+## Firebase Emulator
+
+There are two iOS Schemes, prod and dev. When running dev, your machines IP is sniffed and injected into the info.plist file and then becomes available within the code.
+
+The Firestore config is modified to use this new IP and your app can now communicate with the Firestore Emulator on your local machine. The same applies to calling the live cloud functions vs the local Cloud Function emulator.
+
+All Firebase backend code and emulation is here:
+https://github.com/covid19risk/covidwatch-cloud-functions
 
 Android Peripheral
+
 - Android devices will act as BLE peripherals in the background and they will advertise a service UUID specific to this app.
-- In the advertisement packet they will use the service data field [https://developer.android.com/reference/android/bluetooth/le/AdvertiseData.Builder] to advertise a randomly generated Contact Event Number. 
+- In the advertisement packet they will use the service data field [https://developer.android.com/reference/android/bluetooth/le/AdvertiseData.Builder] to advertise a randomly generated Contact Event Number.
 - They will log all previously advertised CENs, and periodically update the CEN when the app is woken up for Bluetooth or timer events.
 - Functionality will soon be added for iOS centrals to connect to Android peripherals. During this process the iOS central will transmit a CEN and the Android device will log it.
 
 iOS Peripheral
-- iOS devices will act as BLE peripherals in the background and they will advertise a service UUID specific to this app with a readable characteristic exposed. 
+
+- iOS devices will act as BLE peripherals in the background and they will advertise a service UUID specific to this app with a readable characteristic exposed.
 - If a central establishes a connection and requests to read the characteristic field the peripheral will randomly generate a CEN, log it locally, and transmit it to the central.
 
 Android Central
-- Android devices will act as BLE centrals in the background and they will scan for the service UUID specific to this app. 
-- When they read an advertisement packet from an Android peripheral they will log the information in the service data field as the CEN. 
+
+- Android devices will act as BLE centrals in the background and they will scan for the service UUID specific to this app.
+- When they read an advertisement packet from an Android peripheral they will log the information in the service data field as the CEN.
 - Android centrals are unable to detect iOS peripherals.
 
 iOS Central
-- iOS devices will act as BLE centrals in the background and they will scan for the service UUID specific to this app. 
-- When they read an advertisement packet from an Android peripheral they will log the attached service field as the CEN. 
+
+- iOS devices will act as BLE centrals in the background and they will scan for the service UUID specific to this app.
+- When they read an advertisement packet from an Android peripheral they will log the attached service field as the CEN.
 - When they read an advertisement packet from an iOS peripheral they will establish a connection and request the characteristic field. They will then log the returned characteristic field as the CEN and disconnect.
 - Functionality will soon be added for iOS centrals to connect to Android peripherals. During this process the iOS central will transmit a CEN and the Android device will log it.
 
-Under the current model, Android devices will be able to detect other Android devices and iOS devices will be able to detect all devices. The asymmetry of the model is not ideal, but all phones will be able to locally share a Contact Event Number when in the vicinity of other phones, so the requirements specified in the privacy model are achieved. For Android to Android or iOS to iOS detection, two contact event numbers will likely be generated for each interaction (because each phone acts as both a peripheral and a central). This can be trivially adjusted for in the risk model. 
+Under the current model, Android devices will be able to detect other Android devices and iOS devices will be able to detect all devices. The asymmetry of the model is not ideal, but all phones will be able to locally share a Contact Event Number when in the vicinity of other phones, so the requirements specified in the privacy model are achieved. For Android to Android or iOS to iOS detection, two contact event numbers will likely be generated for each interaction (because each phone acts as both a peripheral and a central). This can be trivially adjusted for in the risk model.
 
 In an upcoming update, the ability for iOS centrals to write to Android peripherals will be added. This will enable symmetric communication between all device types and enable an updated cryptographic system.
-
-


### PR DESCRIPTION
- Local development LAN IP of machine is injected into info.plist
- iPhone can connect to Firebase Emulator on dev machine over WiFi
Configured Firestore to use local development IP in dev scheme
- Temporarily changing to tcn-client-ios fork with older swift
- Swift 5.2 doesn't work on Mojave
- Friends don't let friends upgrade OS during a Pandemic